### PR TITLE
Set v4 attribute for generic options

### DIFF
--- a/Jagornet-DHCP/src/com/jagornet/dhcp/option/generic/GenericOptionFactory.java
+++ b/Jagornet-DHCP/src/com/jagornet/dhcp/option/generic/GenericOptionFactory.java
@@ -251,7 +251,12 @@ public class GenericOptionFactory
 							continue;
 						}
 					}
-										
+
+					if(optMap.get(code) instanceof BaseDhcpOption) {
+						if (optionDefType.isSetV4()) {
+							((BaseDhcpOption) optMap.get(code)).setV4(true);
+						}
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Generic options in xml config file (e.g. under filters/filter/v4ConfigOptions/otherOptions) were not properly set as v4 or not. Their v4 xml attribute was not parsed. This resulted in malformed DHCP message due to option length set to.

Signed-off-by: Maros Marsalek <mmarsale@cisco.com>